### PR TITLE
5462 removed the available notations that break the build for PG app …

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -232,8 +232,6 @@ fileprivate extension CALayer {
      ## Author
      Luis Padron
      */
-    @available(*, unavailable,
-    message: "This property is reserved for Interface Builder, use 'ringStyle' instead")
     @IBInspectable open var ibRingStyle: Int = 1 {
         willSet {
             let style = UICircularProgressRingStyle(rawValue: newValue)
@@ -563,8 +561,6 @@ fileprivate extension CALayer {
      ## Author
      Luis Padron
      */
-    @available(*, unavailable,
-    message: "This property is reserved for Interface Builder, use 'outerCapStyle' instead")
     @IBInspectable open var outerRingCapStyle: Int32 = 1 {
         willSet {
             switch newValue {
@@ -666,8 +662,6 @@ fileprivate extension CALayer {
      ## Author
      Luis Padron
      */
-    @available(*, unavailable,
-    message: "This property is reserved for Interface Builder, use 'innerCapStyle' instead")
     @IBInspectable open var innerRingCapStyle: Int32 = 2 {
         willSet {
             switch newValue {


### PR DESCRIPTION
Changes required for this card https://myxplorinfo.atlassian.net/browse/PES-5462 we need to remove a few lines to make the pod source code compile on XCode 15



<img width="1169" alt="Screenshot 2023-07-18 at 12 29 14 pm" src="https://github.com/myxplor/UICircularProgressRing/assets/100399154/d417505e-ff29-46e0-804d-2a89059faba6">

